### PR TITLE
add sortBy for microhs

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,8 +7,8 @@ import qualified DataFrame as D
 
 main :: IO ()
 main = do
-    let highs = [(24 :: Double), 20, 22, 23, 25, 26, 26]
-    let lows = [(14 :: Double), 13, 13, 13, 14, 15, 15]
+    let highs = [(24 :: Double), 20, 22, 23, 25, 26, 26, 20.2, 20.8, 25.2]
+    let lows = [(14 :: Double), 13, 13, 13, 14, 15, 15, 12.1, 12.2, 12.5]
     let df =
             D.fromNamedColumns
                 [ ("Day", D.fromList (take (length highs) (cycle ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"])))
@@ -30,6 +30,8 @@ main = do
                 |> D.select ["Day", "average (fahrenheit)"]
     putStrLn ""
     putStrLn (D.renderMarkdownTable Nothing hotDays)
+    putStrLn $ show (hotDays |> D.sortBy (D.Asc "average (fahrenheit)"))
+    putStrLn $ show (hotDays |> D.sortBy (D.Desc "average (fahrenheit)"))
 
 toFahrenheit :: D.Expr Double -> D.Expr Double
 toFahrenheit t = (t * (9 / 5)) + 2

--- a/dataframe-mhs.cabal
+++ b/dataframe-mhs.cabal
@@ -64,6 +64,7 @@ library
                    ,  DataFrame.Core
                    ,  DataFrame.Expression
                    ,  DataFrame.Functions
+                   ,  DataFrame.Permutation
                    ,  DataFrame.PrettyPrint
 
     -- Modules included in this library but not exported.

--- a/src/DataFrame.hs
+++ b/src/DataFrame.hs
@@ -3,6 +3,7 @@ module DataFrame (
     module DataFrame.Column,
     module DataFrame.Expression,
     module DataFrame.Functions,
+    module DataFrame.Permutation,
     module DataFrame.PrettyPrint,
     (|>),
 ) where
@@ -13,6 +14,7 @@ import DataFrame.Column
 import DataFrame.Core
 import DataFrame.Expression
 import DataFrame.Functions
+import DataFrame.Permutation (sortBy, SortOrder(..))
 import DataFrame.PrettyPrint
 
 (|>) :: a -> (a -> b) -> b

--- a/src/DataFrame/Functions.hs
+++ b/src/DataFrame/Functions.hs
@@ -39,3 +39,6 @@ derive name expr df = DataFrame ((columns df) ++ [(name, interpret expr df)])
 
 select :: [String] -> DataFrame -> DataFrame
 select cols df = df{columns = filter ((`elem` cols) . fst) (columns df)}
+
+selectColumn :: String -> DataFrame -> Column
+selectColumn colname (DataFrame d) = snd $ head $ filter (\x -> fst x == colname) d

--- a/src/DataFrame/Permutation.hs
+++ b/src/DataFrame/Permutation.hs
@@ -1,0 +1,41 @@
+module DataFrame.Permutation where 
+
+import DataFrame.Column
+import DataFrame.Core
+import DataFrame.Functions
+
+import Data.List (sortOn)
+import Data.Ord (Down(..))
+
+-- A bit ugly, but unfortunately because Column is an ADT,
+-- I can't hoist f into a single `where`-clause for getOrderedIndices.
+f :: (a, (b, c)) -> c
+f (_, (_, x)) = x
+
+data SortOrder = Asc String | Desc String
+
+getOrderedIndices :: Bool -> Column -> [Int]
+getOrderedIndices True (CInt xs) = map fst $ sortOn f $ zip [0..] xs
+getOrderedIndices False (CInt xs) = map fst $ sortOn (Down . f) $ zip [0..] xs
+getOrderedIndices True (CDouble xs) = map fst $ sortOn f $ zip [0..] xs
+getOrderedIndices False (CDouble xs) = map fst $ sortOn (Down . f) $ zip [0..] xs
+getOrderedIndices True (CString xs) = map fst $ sortOn f $ zip [0..] xs
+getOrderedIndices False (CString xs) = map fst $ sortOn (Down . f) $ zip [0..] xs
+getOrderedIndices True (CBool xs) = map fst $ sortOn f $ zip [0..] xs
+getOrderedIndices False (CBool xs) = map fst $ sortOn (Down . f) $ zip [0..] xs
+
+orderListBy :: [Int] -> [a] -> [a]
+orderListBy ixs xs = map (xs !!) ixs
+
+orderColumnBy :: [Int] -> Column -> Column
+orderColumnBy ixs (CInt xs) = CInt $ orderListBy ixs xs
+orderColumnBy ixs (CDouble xs) = CDouble $ orderListBy ixs xs
+orderColumnBy ixs (CString xs) = CString $ orderListBy ixs xs
+orderColumnBy ixs (CBool xs) = CBool $ orderListBy ixs xs
+
+orderDataFrameBy :: [Int] -> DataFrame -> DataFrame
+orderDataFrameBy ixs (DataFrame df) = fromNamedColumns $ map (\(colname, col) -> (colname, orderColumnBy ixs col)) df
+
+sortBy :: SortOrder -> DataFrame -> DataFrame
+sortBy (Asc colname) df = orderDataFrameBy (getOrderedIndices True (selectColumn colname df)) df 
+sortBy (Desc colname) df = orderDataFrameBy (getOrderedIndices False (selectColumn colname df)) df 


### PR DESCRIPTION
High-level summary:

1. Using list-based representations aren't necessarily going to work. I know you have an open task to convert everything to `array`, so I won't belabor the point, but you can see that as soon as we implement `sortBy` we use `!!`, which is linear. In fact, `orderListBy` is O(n squared).
2. I feel like the current representation is hard to develop in. The structures are so highly nested: `DataFrame` needs an extractor to obtain`[String, Column]. Then `Column` needs an extractor to obtain `[(Int, a)]`. Then I need `snd` to get `a`.
3. Can't order by multiple columns at the moment, since there's no indirection of `Any`. Since all lists must be of only one type, we can't order by multiple columns.

BTW -- no need to accept this PR: I am just explaining to you my concerns with developing withinin this framework.

Other concerns I have:

1. In order to be effective developers, we need to ensure that developing in MicroHS is a strict subset of developing in Cabal. This is because there isn't really a Cabal equivalent to MicroHS now, so it's just more convenient to use `cabal run` and see what happens, rather than recompiling via MicroHS every time.
2. I am concerned that MicroHS doesn't have a centralized test framework at the moment. 

If it is the case that Type Families will eventually be supported, I'm of the opinion that we should wait until Type Families are supported, and we can just use Vector, because then we can just maintain one package and test that pathway. If we really want to support MicroHS, my opinion is that it is less risky to rip Vector out of DataFrame and replace it entirely by Array.